### PR TITLE
Update for Gnome 3.2 

### DIFF
--- a/windowoverlay-icons/metadata.json
+++ b/windowoverlay-icons/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.0"],
+    "shell-version": ["3.2"],
     "uuid": "windowoverlay-icons@sustmidown.centrum.cz",
     "name": "WindowOverlay Icons",
     "description": "Add application icons to window overview",


### PR DESCRIPTION
Here are the changes to get the window icon overlay extension working with Gnome 3.2.

FYI, there appears to be a load order compatibility bug with native-window-placement@gnome-shell-extensions.gnome.org at the moment.
