### PR TITLE
extension.js: Fix warnings new to gnome-shell 3.24

### DIFF
--- a/windowoverlay-icons/extension.js
+++ b/windowoverlay-icons/extension.js
@@ -70,6 +70,9 @@ function enable() {
         this._windowOverlayIconsExtension.box = new St.Bin({ style_class: 'windowoverlay-application-icon-box' });
         this._windowOverlayIconsExtension.box.set_opacity(settings.get_int('icon-opacity-blur'));
         
+        let result;
+        let background_color;
+        
         [result, background_color] = Gdk.color_parse(settings.get_string('background-color'));
         if (result) {
             this._windowOverlayIconsExtension.box.style = 'background-color: rgba(' +
@@ -138,7 +141,7 @@ function enable() {
         }
         
         // request new icon size
-        if (this._windowOverlayIconsExtension.mipmap_size != icon_mipmap_size || refreshIcon) {
+        if (!this._windowOverlayIconsExtension.mipmap_size || this._windowOverlayIconsExtension.mipmap_size != icon_mipmap_size || refreshIcon) {
             if (this._windowOverlayIconsExtension.icon) {
                 this._windowOverlayIconsExtension.box.remove_actor(this._windowOverlayIconsExtension.icon);
             }


### PR DESCRIPTION
Starting with gnome-shell 3.24 (probably due to using mozjs 38), gnome-shell is warning when using uninitialized variables.